### PR TITLE
chore: update faas-cli and watchdog image references

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,11 +14,11 @@ jobs:
         run: echo "::set-output name=github-sha-short::$(echo $GITHUB_SHA | cut -c
           1-7)"
       - name: Pull template
-        uses: docker://openfaas/faas-cli:latest-root
+        uses: docker://ghcr.io/openfaas/faas-cli:latest-root
         with:
           args: template store pull golang-middleware
       - name: Run shrinkwrap build
-        uses: docker://openfaas/faas-cli:latest-root
+        uses: docker://ghcr.io/openfaas/faas-cli:latest-root
         with:
           args: build -f spinoff.yml --shrinkwrap
       - name: Login to DockerHub
@@ -50,11 +50,11 @@ jobs:
         run: echo "::set-output name=github-sha-short::$(echo $GITHUB_SHA | cut -c
           1-7)"
       - name: Pull template
-        uses: docker://openfaas/faas-cli:latest-root
+        uses: docker://ghcr.io/openfaas/faas-cli:latest-root
         with:
           args: template store pull golang-middleware
       - name: Run shrinkwrap build
-        uses: docker://openfaas/faas-cli:latest-root
+        uses: docker://ghcr.io/openfaas/faas-cli:latest-root
         with:
           args: build -f spinoff-controller.yml --shrinkwrap
       - name: Login to DockerHub

--- a/template/golang-middleware/Dockerfile
+++ b/template/golang-middleware/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.10.6 as watchdog
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:latest as watchdog
 FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22.0-alpine3.21 as build
 
 ARG TARGETPLATFORM


### PR DESCRIPTION
Updated the GitHub Actions workflow to use the latest-root image from ghcr.io for faas-cli. Also updated the Dockerfile to use the latest version of of-watchdog. This ensures we are using the most recent versions of these tools.