### PR TITLE
chore: update golang version in Dockerfile

### DIFF
--- a/template/golang-middleware/Dockerfile
+++ b/template/golang-middleware/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:latest as watchdog
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22.0-alpine3.21 as build
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22-alpine as build
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
Updated the golang version in the Dockerfile from 1.22.0-alpine3.21 to 1.22-alpine. This change ensures compatibility with the latest alpine version and reduces potential issues with version mismatches.