### PR TITLE
feat: update golang-middleware template to Go 1.22

### DIFF
--- a/template/golang-middleware/Dockerfile
+++ b/template/golang-middleware/Dockerfile
@@ -1,5 +1,5 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:latest as watchdog
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22-alpine as build
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.10.6 AS watchdog
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22-alpine AS build
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -11,47 +11,50 @@ RUN apk --no-cache add git
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
-ENV CGO_ENABLED=0
-
 RUN mkdir -p /go/src/handler
 WORKDIR /go/src/handler
 COPY . .
 
-# Add user overrides to the root go.mod, which is the only place "replace" can be used
-RUN cat function/GO_REPLACE.txt >> ./go.mod || exit 0
+ARG GO111MODULE="on"
+ARG GOPROXY=""
+ARG GOFLAGS=""
+ARG CGO_ENABLED=0
+ENV CGO_ENABLED=${CGO_ENABLED}
 
 # Run a gofmt and exclude all vendored code.
 RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./function/vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
 
-ARG GO111MODULE="off"
-ARG GOPROXY=""
-ARG GOFLAGS=""
-
 WORKDIR /go/src/handler/function
+RUN mkdir -p /go/src/handler/function/static
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go test ./... -cover
 
 WORKDIR /go/src/handler
-RUN CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-  go build --ldflags "-s -w" -a -installsuffix cgo -o handler .
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build --ldflags "-s -w" -o handler .
 
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.21
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.20.2 AS ship
+
 # Add non root user and certs
 RUN apk --no-cache add ca-certificates \
-  && addgroup -S app && adduser -S -g app app \
-  && mkdir -p /home/app \
-  && chown app /home/app
+    && addgroup -S app && adduser -S -g app app
+
+# Split instructions so that buildkit can run & cache
+# the previous command ahead of time.
+RUN mkdir -p /home/app \
+    && chown app /home/app
 
 WORKDIR /home/app
 
-COPY --from=build --chown=app /go/src/handler/handler    .
-COPY --from=build --chown=app /usr/bin/fwatchdog         .
-COPY --from=build --chown=app /go/src/handler/function/  .
+COPY --from=build --chown=app /go/src/handler/handler           .
+COPY --from=build --chown=app /usr/bin/fwatchdog                .
+COPY --from=build --chown=app /go/src/handler/function/static   static
 
 USER app
 
 ENV fprocess="./handler"
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:8082"
+ENV prefix_logs="false"
 
 CMD ["./fwatchdog"]

--- a/template/golang-middleware/function/handler.go
+++ b/template/golang-middleware/function/handler.go
@@ -2,7 +2,7 @@ package function
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -12,11 +12,11 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 	if r.Body != nil {
 		defer r.Body.Close()
 
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 
 		input = body
 	}
 
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(fmt.Sprintf("Hello world, input was: %s", string(input))))
+	w.Write([]byte(fmt.Sprintf("Body: %s", string(input))))
 }

--- a/template/golang-middleware/go.mod
+++ b/template/golang-middleware/go.mod
@@ -1,5 +1,3 @@
 module handler
 
-go 1.13
-
-replace handler/function => ./function
+go 1.22

--- a/template/golang-middleware/main.go
+++ b/template/golang-middleware/main.go
@@ -24,6 +24,7 @@ const defaultTimeout = 10 * time.Second
 func main() {
 	readTimeout := parseIntOrDurationValue(os.Getenv("read_timeout"), defaultTimeout)
 	writeTimeout := parseIntOrDurationValue(os.Getenv("write_timeout"), defaultTimeout)
+	healthInterval := parseIntOrDurationValue(os.Getenv("healthcheck_interval"), writeTimeout)
 
 	s := &http.Server{
 		Addr:           fmt.Sprintf(":%d", 8082),
@@ -34,10 +35,10 @@ func main() {
 
 	http.HandleFunc("/", function.Handle)
 
-	listenUntilShutdown(s, writeTimeout)
+	listenUntilShutdown(s, healthInterval, writeTimeout)
 }
 
-func listenUntilShutdown(s *http.Server, shutdownTimeout time.Duration) {
+func listenUntilShutdown(s *http.Server, shutdownTimeout time.Duration, writeTimeout time.Duration) {
 	idleConnsClosed := make(chan struct{})
 	go func() {
 		sig := make(chan os.Signal, 1)
@@ -45,17 +46,17 @@ func listenUntilShutdown(s *http.Server, shutdownTimeout time.Duration) {
 
 		<-sig
 
-		log.Printf("[entrypoint] SIGTERM received.. shutting down server in %s\n", shutdownTimeout.String())
-
+		log.Printf("[entrypoint] SIGTERM: no connections in: %s", shutdownTimeout.String())
 		<-time.Tick(shutdownTimeout)
 
-		if err := s.Shutdown(context.Background()); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), writeTimeout)
+		defer cancel()
+
+		if err := s.Shutdown(ctx); err != nil {
 			log.Printf("[entrypoint] Error in Shutdown: %v", err)
 		}
 
-		log.Printf("[entrypoint] No new connections allowed. Exiting in: %s\n", shutdownTimeout.String())
-
-		<-time.Tick(shutdownTimeout)
+		log.Printf("[entrypoint] Exiting.")
 
 		close(idleConnsClosed)
 	}()

--- a/template/golang-middleware/template.yml
+++ b/template/golang-middleware/template.yml
@@ -1,12 +1,11 @@
 language: golang-middleware
 fprocess: ./handler
 welcome_message: |
-  You have created a new function which uses Golang 1.13.
+  You have created a new function which uses Go 1.22 and Alpine
+  Linux as its base image.
 
-  To include third-party dependencies, use Go modules and use
-  "--build-arg GO111MODULE=on" with faas-cli build or configure this  
+  To disable the go module, for private vendor code, please use
+  "--build-arg GO111MODULE=off" with faas-cli build or configure this
   via your stack.yml file.
 
-  See more: https://docs.openfaas.com/cli/templates/
-  For detailed examples:
-  https://github.com/openfaas-incubator/golang-http-template
+  Learn more: https://docs.openfaas.com/languages/go/


### PR DESCRIPTION
- Updated Dockerfile to use specific versions for watchdog and Go.
- Added ARG and ENV for GO111MODULE, GOPROXY, GOFLAGS, and CGO_ENABLED.
- Changed ioutil.ReadAll to io.ReadAll in handler.go.
- Updated go.mod to use Go 1.22.
- Added healthcheck_interval in main.go and modified shutdown logic.
- Updated template.yml to reflect Go 1.22 and Alpine Linux.