### PR TITLE
feat: add TARGETOS and TARGETARCH build args

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -40,6 +40,8 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/spinoff:latest
           build-args: |
             GO111MODULE=on
+            TARGETOS=linux
+            TARGETARCH=amd64
   spinoff-controller-func-build:
     runs-on: ubuntu-latest
     steps:
@@ -76,6 +78,8 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/spinoff-controller:latest
           build-args: |
             GO111MODULE=on
+            TARGETOS=linux
+            TARGETARCH=amd64
   spinoff-infra-boostrap:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Added TARGETOS and TARGETARCH build arguments to Docker image build steps in the GitHub Actions workflow. This ensures the images are built for the correct OS and architecture.