### PR TITLE
feat: add existing SSH key data source and update outputs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,10 @@
+data "hcloud_ssh_key" "existing" {
+  name = "spinoff-key"
+}
+
 resource "hcloud_ssh_key" "default" {
-  name       = "my-ssh-key"
+  count      = length(data.hcloud_ssh_key.existing.id) == 0 ? 1 : 0
+  name       = "spinoff-key"
   public_key = file("~/.ssh/id_terraform_rsa.pub")
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,10 +4,10 @@ output "gateway_url" {
 
 output "password" {
   value = random_password.password.result
-  sensitive = true
+  sensitive = false
 }
 
 output "login_cmd" {
   value = "faas-cli login -g http://${hcloud_server.faasd_node.ipv4_address}:8080 -p ${random_password.password.result}"
-  sensitive = true
+  sensitive = false
 }

--- a/stack.yml
+++ b/stack.yml
@@ -1,6 +1,7 @@
 ---
 provider:
   name: openfaas
+  gateway: http://$FAASD_NODE_IP:8080
 functions:
   spinoff:
     lang: golang-middleware


### PR DESCRIPTION
- Added data source for existing SSH key in main.tf
- Updated hcloud_ssh_key resource to use existing key if available
- Changed sensitive attribute to false for password and login_cmd outputs
- Added gateway URL to stack.yml for openfaas provider